### PR TITLE
By removing the copy you make sure there's no leak with ARC disabled.

### DIFF
--- a/Utils/DDURLParser.m
+++ b/Utils/DDURLParser.m
@@ -22,7 +22,7 @@
 		//ignore the beginning of the string and skip to the vars
         [scanner scanUpToString:@"?" intoString:nil];
         while ([scanner scanUpToString:@"&" intoString:&tempString]) {
-            [vars addObject:[tempString copy]];
+            [vars addObject:tempString];
         }
         variables = vars;
     }


### PR DESCRIPTION
Fixed a memory leak with ARC disabled.  The copy was unnecessary as well as the string is each time a new object.
